### PR TITLE
Allow users to specify custom tokens

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,6 @@ runs:
 
         if [ "${{ inputs.push }}" = "true" -a "$(git status | grep diverged)" ]; then
             ORIGIN_URL=$(git remote get-url origin)
-            git push "$ORIGIN_URL/https:\/\//https:\/\/$GITHUB_TOKEN@" $(git branch --show-current) --force-with-lease;
+            git push "${ORIGIN_URL/https:\/\//https:\/\/$GITHUB_TOKEN@}" $(git branch --show-current) --force-with-lease;
         fi;
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,9 @@ runs:
         set -ex;
 
         UPSTREAM=${{ inputs.upstream }};
+        GITHUB_TOKEN=${{ inputs.token }};
         if [ -z $UPSTREAM ]; then
-            echo ${{ inputs.token }} | gh auth login --with-token;
+            echo GITHUB_TOKEN | gh auth login --with-token;
             UPSTREAM=$(gh api repos/:owner/:repo --jq .parent.full_name);
             if [ -z $UPSTREAM ]; then echo "Can't find upstream" >&2 && exit 1; fi;
         fi;
@@ -51,11 +52,11 @@ runs:
 
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com";
         git config --local user.name  "GitHub Actions";
-        git config --local user.password ${{ inputs.token }}
 
         git rebase upstream/${{ inputs.branch }};
 
         if [ "${{ inputs.push }}" = "true" -a "$(git status | grep diverged)" ]; then
-            git push origin $(git branch --show-current) --force-with-lease;
+            ORIGIN_URL=${`git remote get-url origin`/https:\/\//https:\/\/$GITHUB_TOKEN@}
+            git push $ORIGIN_URL $(git branch --show-current) --force-with-lease;
         fi;
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,7 @@ runs:
 
         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com";
         git config --local user.name  "GitHub Actions";
+        git config --local user.password ${{ inputs.token }}
 
         git rebase upstream/${{ inputs.branch }};
 

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
         git rebase upstream/${{ inputs.branch }};
 
         if [ "${{ inputs.push }}" = "true" -a "$(git status | grep diverged)" ]; then
-            ORIGIN_URL=$(git remote get-url origin)
+            ORIGIN_URL=$(git remote get-url origin);
             git push "${ORIGIN_URL/https:\/\//https:\/\/$GITHUB_TOKEN@}" $(git branch --show-current) --force-with-lease;
         fi;
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: Do the force push in this action
     required: false
     default:  true
+  token:
+    description: GitHub token to access to API and git
+    required: false
+    default: ${{ github.token }}
 
 runs:
   using: composite
@@ -30,7 +34,7 @@ runs:
 
         UPSTREAM=${{ inputs.upstream }};
         if [ -z $UPSTREAM ]; then
-            echo ${{ github.token }} | gh auth login --with-token;
+            echo ${{ inputs.token }} | gh auth login --with-token;
             UPSTREAM=$(gh api repos/:owner/:repo --jq .parent.full_name);
             if [ -z $UPSTREAM ]; then echo "Can't find upstream" >&2 && exit 1; fi;
         fi;

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ runs:
         git rebase upstream/${{ inputs.branch }};
 
         if [ "${{ inputs.push }}" = "true" -a "$(git status | grep diverged)" ]; then
-            ORIGIN_URL=${`git remote get-url origin`/https:\/\//https:\/\/$GITHUB_TOKEN@}
-            git push $ORIGIN_URL $(git branch --show-current) --force-with-lease;
+            ORIGIN_URL=$(git remote get-url origin)
+            git push "$ORIGIN_URL/https:\/\//https:\/\/$GITHUB_TOKEN@" $(git branch --show-current) --force-with-lease;
         fi;
       shell: bash


### PR DESCRIPTION
This allows the user to specify their token using a `token` input, defaulting to the regular `${{ github.token }}` if not.

## Summary by Sourcery

New Features:
- Introduce a new input parameter 'token' to allow users to specify a custom GitHub token for API and git access.