### PR TITLE
Fixed token login

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
         UPSTREAM=${{ inputs.upstream }};
         GITHUB_TOKEN=${{ inputs.token }};
         if [ -z $UPSTREAM ]; then
-            echo GITHUB_TOKEN | gh auth login --with-token;
+            echo $GITHUB_TOKEN | gh auth login --with-token;
             UPSTREAM=$(gh api repos/:owner/:repo --jq .parent.full_name);
             if [ -z $UPSTREAM ]; then echo "Can't find upstream" >&2 && exit 1; fi;
         fi;


### PR DESCRIPTION
Echo ``$GITHUB_TOKEN`` environment variable into login command instead of ``GITHUB_TOKEN`` string literal.

## Summary by Sourcery

Bug Fixes:
- Fix token login by using the GITHUB_TOKEN environment variable instead of a string literal in the authentication command.